### PR TITLE
verbose curl error message when post do not work

### DIFF
--- a/src/push_admin/Application.php
+++ b/src/push_admin/Application.php
@@ -153,6 +153,7 @@ class Application
 
         $ret = @curl_exec($ch);
         if ($ret === false) {
+            $this->printLogMethodOperate('curl_exec error #' . curl_errno($ch) . ' : ' . curl_error($ch), __FUNCTION__ . ':' . __LINE__, Constants::HW_PUSH_LOG_ERROR_LEVEL);
             return null;
         }
 


### PR DESCRIPTION
On our side, we have lookup problems and the code wasn't showing any error message: the if statement had no logging if curl has an error. This is now sloved.